### PR TITLE
a__cgo.go: we need libm on every Unix, not just Linux

### DIFF
--- a/internal/libwebp/a__cgo.go
+++ b/internal/libwebp/a__cgo.go
@@ -3,5 +3,5 @@
 
 package libwebp
 
-// #cgo linux LDFLAGS: -lm
+// #cgo unix LDFLAGS: -lm
 import "C"


### PR DESCRIPTION
should fix #5

need go 1.19 according to https://twitter.com/inancgumus/status/1546490976130269190